### PR TITLE
feat: add Docker configuration for databerry2 deployment

### DIFF
--- a/docker/.env.portainer
+++ b/docker/.env.portainer
@@ -1,24 +1,24 @@
 # Domain used by Traefik router
-DOMAIN=dashboard.example.com
+DOMAIN=databerry2.clinichub.app.br
 
 # Analysze js bundle
 ANALYZE=false
 
 # Next Auth
-NEXTAUTH_SECRET=change_me
-NEXTAUTH_URL=https://dashboard.example.com
+NEXTAUTH_SECRET=example_nextauth_secret
+NEXTAUTH_URL=https://databerry2.clinichub.app.br
 
-JWT_SECRET=replace_with_secure_random_value # openssl rand -hex 32
+JWT_SECRET=example_jwt_secret # openssl rand -hex 32
 
 # Services
 OPENAI_API_KEY=
 OPENROUTER_API_KEY=
 
 # Databases
-DATABASE_URL=postgresql://admin:password@pgdb:5432/databerry
-QDRANT_API_URL=http://qdrant:6333
+DATABASE_URL=postgresql://admin:password@pgdb:5432/databerry2
+QDRANT_API_URL=http://qdrant2:6333
 REDIS_URL=redis://redis:6379
-QDRANT_API_KEY=secure_qdrant_key
+QDRANT_API_KEY=secure_qdrant_key_2
 
 # CHROMIUM is needed for puppeteer (WebSite loader)
 # for macos local dev
@@ -26,7 +26,7 @@ QDRANT_API_KEY=secure_qdrant_key
 CHROMIUM_PATH=/usr/bin/chromium
 
 # endpoint of the remote browser
-BROWSER_API=https://dashboard.example.com/api/browser
+BROWSER_API=https://databerry2.clinichub.app.br/api/browser
 
 # AWS S3
 APP_AWS_ACCESS_KEY=
@@ -42,7 +42,7 @@ INBOUND_EMAIL_AWS_SECRET_KEY=${APP_AWS_SECRET_KEY}
 INBOUND_EMAIL_AWS_S3_ENDPOINT=${APP_AWS_S3_ENDPOINT}
 INBOUND_EMAIL_APP_AWS_S3_FORCE_PATH_STYLE=${APP_AWS_S3_FORCE_PATH_STYLE}
 
-NEXT_PUBLIC_DASHBOARD_URL=https://dashboard.example.com
+NEXT_PUBLIC_DASHBOARD_URL=https://databerry2.clinichub.app.br
 
 # Emails
 EMAIL_SERVER=smtp://smtp.example.com:587

--- a/docker/docker-compose.databerry2.yml
+++ b/docker/docker-compose.databerry2.yml
@@ -1,0 +1,46 @@
+version: '3'
+
+services:
+  databerry2:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+      args:
+        SCOPE: dashboard
+    env_file:
+      - .env.portainer
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      QDRANT_API_URL: ${QDRANT_API_URL}
+      QDRANT_API_KEY: ${QDRANT_API_KEY}
+      REDIS_URL: ${REDIS_URL}
+      NEXTAUTH_URL: ${NEXTAUTH_URL}
+      NEXTAUTH_SECRET: ${NEXTAUTH_SECRET}
+      JWT_SECRET: ${JWT_SECRET}
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.databerry2.rule=Host(`databerry2.clinichub.app.br`)"
+      - "traefik.http.routers.databerry2.entrypoints=websecure"
+      - "traefik.http.routers.databerry2.tls=true"
+      - "traefik.http.services.databerry2.loadbalancer.server.port=3000"
+    networks:
+      - network_public
+      - internal
+    depends_on:
+      - qdrant2
+
+  qdrant2:
+    image: qdrant/qdrant:v1.6.1
+    volumes:
+      - qdrant_storage_2:/qdrant/storage
+    networks:
+      - internal
+
+volumes:
+  qdrant_storage_2:
+
+networks:
+  network_public:
+    external: true
+  internal:
+    driver: bridge


### PR DESCRIPTION
## Summary
- add docker compose file for databerry2 with traefik routing and separate qdrant volume
- configure `.env.portainer` for databerry2 domain and service endpoints

## Testing
- `pnpm lint` *(fails: turbo: not found)*
- `pnpm install` *(fails: ERR_PNPM_FETCH_403)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4e5cab6c83318e3fb87321fd8ea6